### PR TITLE
fix(): extra class on section not set

### DIFF
--- a/modules/ui_styles_layout_builder/ui_styles_layout_builder.module
+++ b/modules/ui_styles_layout_builder/ui_styles_layout_builder.module
@@ -175,7 +175,7 @@ function _ui_styles_layout_builder_submit_section_form(array $form, FormStateInt
   $formObject = $formState->getFormObject();
   $section = $formObject->getCurrentSection();
   $section->setThirdPartySetting('ui_styles', 'selected', $selected);
-  $section->setThirdPartySetting('ui_styles', 'extra', $formState->getValue('_ui_styles_extra'));
+  $section->setThirdPartySetting('ui_styles', 'extra', $formState->getValue('ui_style')['_ui_styles_extra']);
 }
 
 /**


### PR DESCRIPTION
### Context

As a site builder, when adding `Extra classes` on a **section**, the extra class in not properly set in the code.

In the code the form value is missing a parent.